### PR TITLE
Move JUnit into Test Scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
It's not needed in production. Just saw unit in my dependency tree.