### PR TITLE
Make classes serializable

### DIFF
--- a/src/main/java/org/fhir/ucum/BaseUnit.java
+++ b/src/main/java/org/fhir/ucum/BaseUnit.java
@@ -13,8 +13,9 @@ package org.fhir.ucum;
 
 public class BaseUnit extends Unit {
 
-
-	/**
+    private static final long serialVersionUID = 2694895021527732848L;
+    
+    /**
 	 * abbrevation for property
 	 */
 	private char dim;

--- a/src/main/java/org/fhir/ucum/Concept.java
+++ b/src/main/java/org/fhir/ucum/Concept.java
@@ -11,12 +11,15 @@
 
 package org.fhir.ucum;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class Concept {
+public class Concept implements Serializable {
 
-	private ConceptKind kind;
+    private static final long serialVersionUID = 4762687914157070849L;
+    
+    private ConceptKind kind;
 	/**
 	 * case sensitive code for this concept
 	 */

--- a/src/main/java/org/fhir/ucum/Decimal.java
+++ b/src/main/java/org/fhir/ucum/Decimal.java
@@ -12,6 +12,8 @@ package org.fhir.ucum;
  *    Health Intersections P/L - port to Java
  *******************************************************************************/
 
+import java.io.Serializable;
+
 /**
     Precision aware Decimal implementation. Any size number with any number of significant digits is supported.
 
@@ -40,9 +42,11 @@ package org.fhir.ucum;
  * @author Grahame
  *
  */
-public class Decimal {
+public class Decimal implements Serializable {
 
-	private int precision;
+    private static final long serialVersionUID = 8336134891785919162L;
+    
+    private int precision;
 	private boolean scientific;
 	private boolean negative;
 	private String digits;

--- a/src/main/java/org/fhir/ucum/DefinedUnit.java
+++ b/src/main/java/org/fhir/ucum/DefinedUnit.java
@@ -14,7 +14,9 @@ package org.fhir.ucum;
 
 public class DefinedUnit extends Unit{
 
-	/**
+    private static final long serialVersionUID = 6610597337302313079L;
+    
+    /**
 	 * whether this is a metric unit or not
 	 */
 	private boolean metric;

--- a/src/main/java/org/fhir/ucum/Prefix.java
+++ b/src/main/java/org/fhir/ucum/Prefix.java
@@ -13,8 +13,10 @@ package org.fhir.ucum;
 
 
 public class Prefix extends Concept {
-	
-	/**
+
+    private static final long serialVersionUID = 7489713906606871520L;
+    
+    /**
 	 * value for the prefix.  
 	 */
 	private Decimal value; // 1^-24 through to 1^24

--- a/src/main/java/org/fhir/ucum/UcumEssenceService.java
+++ b/src/main/java/org/fhir/ucum/UcumEssenceService.java
@@ -40,9 +40,10 @@ import org.fhir.ucum.special.Registry;
  */
 public class UcumEssenceService implements UcumService {
 
+    private static final long serialVersionUID = 1058845586935921655L;
 	public static final String UCUM_OID = "2.16.840.1.113883.6.8";
-	
-	private UcumModel model;
+
+    private UcumModel model;
 	private Registry handlers = new Registry();
 	
 	/**

--- a/src/main/java/org/fhir/ucum/UcumModel.java
+++ b/src/main/java/org/fhir/ucum/UcumModel.java
@@ -11,13 +11,16 @@
 
 package org.fhir.ucum;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public class UcumModel {
+public class UcumModel implements Serializable {
 
-	/**
+    private static final long serialVersionUID = 2263441561255569053L;
+    
+    /**
 	 * version="1.7" 
 	 */
 	private String version;

--- a/src/main/java/org/fhir/ucum/UcumService.java
+++ b/src/main/java/org/fhir/ucum/UcumService.java
@@ -12,6 +12,7 @@ package org.fhir.ucum;
  *    Health Intersections - ongoing maintenance
  *******************************************************************************/
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -25,7 +26,7 @@ import java.util.Set;
  * @author Grahame Grieve
  *
  */
-public interface UcumService {
+public interface UcumService extends Serializable {
 
 	/**
 	 * provided for various utility/QA uses. Should not be used 

--- a/src/main/java/org/fhir/ucum/Unit.java
+++ b/src/main/java/org/fhir/ucum/Unit.java
@@ -14,7 +14,9 @@ package org.fhir.ucum;
 
 public abstract class Unit extends Concept {
 
-	/**
+    private static final long serialVersionUID = -359123350391877225L;
+    
+    /**
 	 * kind of thing this base unit represents
 	 */
 	private String property;

--- a/src/main/java/org/fhir/ucum/Value.java
+++ b/src/main/java/org/fhir/ucum/Value.java
@@ -11,9 +11,13 @@
 
 package org.fhir.ucum;
 
-public class Value {
+import java.io.Serializable;
 
-	private String unit;
+public class Value implements Serializable {
+
+    private static final long serialVersionUID = 6179476364128662688L;
+    
+    private String unit;
 	
 	private String unitUC;
 	

--- a/src/main/java/org/fhir/ucum/special/CelsiusHandler.java
+++ b/src/main/java/org/fhir/ucum/special/CelsiusHandler.java
@@ -15,7 +15,9 @@ import org.fhir.ucum.Decimal;
 
 public class CelsiusHandler extends SpecialUnitHandler {
 
-	@Override
+    private static final long serialVersionUID = 8622694656482031531L;
+
+    @Override
 	public String getCode() {
 		return "Cel";
 	}

--- a/src/main/java/org/fhir/ucum/special/FahrenheitHandler.java
+++ b/src/main/java/org/fhir/ucum/special/FahrenheitHandler.java
@@ -15,7 +15,9 @@ import org.fhir.ucum.Decimal;
 
 public class FahrenheitHandler extends SpecialUnitHandler {
 
-	@Override
+    private static final long serialVersionUID = 5300754465863682114L;
+
+    @Override
 	public String getCode() {
 		return "[degF]";
 	}

--- a/src/main/java/org/fhir/ucum/special/HoldingHandler.java
+++ b/src/main/java/org/fhir/ucum/special/HoldingHandler.java
@@ -22,7 +22,9 @@ import org.fhir.ucum.Decimal;
  */
 public class HoldingHandler extends SpecialUnitHandler {
 
-	private String code;
+    private static final long serialVersionUID = -6165027832340262895L;
+    
+    private String code;
 	private String units;
 	private Decimal value = Decimal.one();
 	

--- a/src/main/java/org/fhir/ucum/special/Registry.java
+++ b/src/main/java/org/fhir/ucum/special/Registry.java
@@ -11,14 +11,17 @@
 
 package org.fhir.ucum.special;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.fhir.ucum.Decimal;
 
-public class Registry {
+public class Registry implements Serializable {
 
-	Map<String, SpecialUnitHandler> handlers = new HashMap<String, SpecialUnitHandler>();
+    private static final long serialVersionUID = 3809426006717720452L;
+    
+    Map<String, SpecialUnitHandler> handlers = new HashMap<String, SpecialUnitHandler>();
 
 	public Registry() {
 		super();

--- a/src/main/java/org/fhir/ucum/special/SpecialUnitHandler.java
+++ b/src/main/java/org/fhir/ucum/special/SpecialUnitHandler.java
@@ -11,11 +11,14 @@
 
 package org.fhir.ucum.special;
 
+import java.io.Serializable;
 import org.fhir.ucum.Decimal;
 
-public abstract class SpecialUnitHandler {
+public abstract class SpecialUnitHandler implements Serializable {
 
-	/**
+    private static final long serialVersionUID = 1000724308948489980L;
+
+    /**
 	 * Used to connect this handler with the case sensitive unit
 	 * @return
 	 */


### PR DESCRIPTION
This change ensures that the core classes within the library all implement Serializable.

This allows the library to be used in distributed computing contexts, such as Apache Spark.