### PR TITLE
Gg 202307 bye bye=xpp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,16 +37,6 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3</artifactId>
-            <version>1.1.4c</version>
-        </dependency>
-        <dependency>
-            <groupId>xpp3</groupId>
-            <artifactId>xpp3_xpath</artifactId>
-            <version>1.1.4c</version>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/fhir/ucum/UcumEssenceService.java
+++ b/src/main/java/org/fhir/ucum/UcumEssenceService.java
@@ -19,6 +19,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.fhir.ucum.definitions.DefinitionsProvider;
+import org.fhir.ucum.definitions.DefinitionsProviderFactory;
+import org.fhir.ucum.definitions.XmlDefinitionsParser;
 import org.fhir.ucum.special.Registry;
 
 
@@ -54,7 +57,7 @@ public class UcumEssenceService implements UcumService {
 		super();
 		assert stream != null : paramError("factory", "stream", "must not be null");
 		try {
-			model = new DefinitionParser().parse(stream);
+			model = DefinitionsProviderFactory.getProvider().parse(stream);
 		} catch (Exception e) {
 			throw new UcumException(e); 
 		}
@@ -69,7 +72,7 @@ public class UcumEssenceService implements UcumService {
 		super();
 		assert new File(filename).exists() : paramError("factory", "file", "must exist");
 		try {
-			model = new DefinitionParser().parse(filename);
+			model = new XmlDefinitionsParser().parse(filename);
 		} catch (Exception e) {
 			throw new UcumException(e); 
 		}

--- a/src/main/java/org/fhir/ucum/definitions/DefinitionsProvider.java
+++ b/src/main/java/org/fhir/ucum/definitions/DefinitionsProvider.java
@@ -1,0 +1,19 @@
+package org.fhir.ucum.definitions;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.fhir.ucum.UcumException;
+import org.fhir.ucum.UcumModel;
+import org.xml.sax.SAXException;
+
+public interface DefinitionsProvider {
+  public UcumModel parse(String filename) throws UcumException;
+  public UcumModel parse(InputStream stream) throws UcumException;
+  
+}

--- a/src/main/java/org/fhir/ucum/definitions/DefinitionsProviderFactory.java
+++ b/src/main/java/org/fhir/ucum/definitions/DefinitionsProviderFactory.java
@@ -1,0 +1,15 @@
+package org.fhir.ucum.definitions;
+
+public class DefinitionsProviderFactory {
+
+  private static DefinitionsProvider provider = new XmlDefinitionsParser();
+
+  public static DefinitionsProvider getProvider() {
+    return provider;
+  }
+
+  public static void setProvider(DefinitionsProvider provider) {
+    DefinitionsProviderFactory.provider = provider;
+  }
+  
+}

--- a/src/main/java/org/fhir/ucum/definitions/XmlDefinitionsParser.java
+++ b/src/main/java/org/fhir/ucum/definitions/XmlDefinitionsParser.java
@@ -9,7 +9,7 @@
  *    Kestral Computing P/L - initial implementation
  *******************************************************************************/
 
-package org.fhir.ucum;
+package org.fhir.ucum.definitions;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -27,6 +27,13 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.fhir.ucum.BaseUnit;
+import org.fhir.ucum.Decimal;
+import org.fhir.ucum.DefinedUnit;
+import org.fhir.ucum.Prefix;
+import org.fhir.ucum.UcumException;
+import org.fhir.ucum.UcumModel;
+import org.fhir.ucum.Value;
 import org.fhir.ucum.utils.XmlUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -40,34 +47,42 @@ import org.xml.sax.SAXException;
  *
  */
 
-public class DefinitionParser {
+public class XmlDefinitionsParser implements DefinitionsProvider {
 
-	public UcumModel parse(String filename) throws UcumException, IOException, ParseException, SAXException, ParserConfigurationException  {
-		return parse(new FileInputStream(new File(filename)));
+	public UcumModel parse(String filename) throws UcumException  {
+	  try {
+	    return parse(new FileInputStream(new File(filename)));
+    } catch (Exception e) {
+      throw new UcumException(e);
+    } 
 	}
 
-	public UcumModel parse(InputStream stream) throws IOException, ParseException, UcumException, SAXException, ParserConfigurationException  {
-	  Document doc = XmlUtils.parseDOM(stream);
-    Element element = doc.getDocumentElement();
+	public UcumModel parse(InputStream stream) throws UcumException {
+	  try {
+	    Document doc = XmlUtils.parseDOM(stream);
+	    Element element = doc.getDocumentElement();
 
-		if (!element.getNodeName().equals("root")) 
-			throw new UcumException("Unable to process XML document: expected 'root' but found '"+element.getNodeName()+"'");
-		DateFormat fmt = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss' 'Z");
-		Date date = fmt.parse(element.getAttribute("revision-date").substring(7, 32));        
-		UcumModel root = new UcumModel(element.getAttribute("version"), element.getAttribute("revision"), date);
-		Element focus = XmlUtils.getFirstChild(element);
-		while (focus != null) {
-			if (focus.getNodeName().equals("prefix")) 
-				root.getPrefixes().add(parsePrefix(focus));
-			else if (focus.getNodeName().equals("base-unit")) 
-				root.getBaseUnits().add(parseBaseUnit(focus));
-			else if (focus.getNodeName().equals("unit")) 
-				root.getDefinedUnits().add(parseUnit(focus));
-			else 
-				throw new UcumException("unknown element name "+focus.getNodeName());
-			focus = XmlUtils.getNextSibling(focus);
-		}
-		return root;
+	    if (!element.getNodeName().equals("root")) 
+	      throw new UcumException("Unable to process XML document: expected 'root' but found '"+element.getNodeName()+"'");
+	    DateFormat fmt = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss' 'Z");
+	    Date date = fmt.parse(element.getAttribute("revision-date").substring(7, 32));        
+	    UcumModel root = new UcumModel(element.getAttribute("version"), element.getAttribute("revision"), date);
+	    Element focus = XmlUtils.getFirstChild(element);
+	    while (focus != null) {
+	      if (focus.getNodeName().equals("prefix")) 
+	        root.getPrefixes().add(parsePrefix(focus));
+	      else if (focus.getNodeName().equals("base-unit")) 
+	        root.getBaseUnits().add(parseBaseUnit(focus));
+	      else if (focus.getNodeName().equals("unit")) 
+	        root.getDefinedUnits().add(parseUnit(focus));
+	      else 
+	        throw new UcumException("unknown element name "+focus.getNodeName());
+	      focus = XmlUtils.getNextSibling(focus);
+	    }
+	    return root;
+	  } catch (Exception e) {
+	    throw new UcumException(e);
+	  }
 	}
 
 

--- a/src/main/java/org/fhir/ucum/utils/XmlUtils.java
+++ b/src/main/java/org/fhir/ucum/utils/XmlUtils.java
@@ -1,0 +1,67 @@
+package org.fhir.ucum.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+
+public class XmlUtils {
+
+  public static Document parseDOM(InputStream stream) throws ParserConfigurationException, SAXException, IOException {
+    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+    factory.setNamespaceAware(false);
+    DocumentBuilder builder = factory.newDocumentBuilder();
+    Document doc = builder.parse(stream);
+    return doc;
+  }
+
+  public static Element getNamedChild(Element e, String name) {
+    Element c = getFirstChild(e);
+    while (c != null && !name.equals(c.getLocalName()) && !name.equals(c.getNodeName()))
+      c = getNextSibling(c);
+    return c;
+  }
+  
+  public static String getNamedChildText(Element element, String name) {
+    Element e = getNamedChild(element, name);
+    return e == null ? null : e.getTextContent();
+  }
+  
+  public static Element getFirstChild(Element e) {
+    if (e == null)
+      return null;
+    Node n = e.getFirstChild();
+    while (n != null && n.getNodeType() != Node.ELEMENT_NODE)
+      n = n.getNextSibling();
+    return (Element) n;
+  }
+
+
+  public static Element getNextSibling(Element e) {
+    Node n = e.getNextSibling();
+    while (n != null && n.getNodeType() != Node.ELEMENT_NODE)
+      n = n.getNextSibling();
+    return (Element) n;
+  }
+
+
+  public static List<Element> getNamedChildren(Element e, String name) {
+    List<Element> res = new ArrayList<Element>();
+    Element c = getFirstChild(e);
+    while (c != null) {
+      if (name.equals(c.getLocalName()) || name.equals(c.getNodeName()) )
+        res.add(c);
+      c = getNextSibling(c);
+    }
+    return res;
+  }
+}


### PR DESCRIPTION
This PR makes two set of changes

1. Remove XPP and replace it with plain DOM parsing. Given that the relevant file is ~2000 lines, it's nothing anyway. So bye bye to dependency problems
2. Drop in the DefinitionsProvider interface and a factory for it. The default loader is the DOM loader, but if someone really wants a different loader, they just set it on the factory
3. 