### PR TITLE
fix for #6 - internal rounding issue is a problem

### DIFF
--- a/src/main/java/org/fhir/ucum/Converter.java
+++ b/src/main/java/org/fhir/ucum/Converter.java
@@ -59,7 +59,7 @@ public class Converter {
 	}
 	
 	private Canonical normalise(String indent, Term term) throws UcumException  {
-		Canonical result = new Canonical(new Decimal(1));
+		Canonical result = new Canonical(new Decimal("1.000000000000000000000000000000"));
 		
 		debug(indent, "canonicalise", term);
     boolean div = false;

--- a/src/main/java/org/fhir/ucum/Decimal.java
+++ b/src/main/java/org/fhir/ucum/Decimal.java
@@ -820,4 +820,38 @@ public class Decimal {
   public int hashCode() {
     return asDecimal().hashCode();
   }
+
+  public void limitPrecisionTo(Decimal other) {
+    // precision can't be greater than other 
+    if (precision > other.precision) {
+      precision = other.precision;
+    }
+  }
+
+  public void checkForCouldBeWholeNumber() {
+    // whole numbers are tricky - they have implied infinite precision, but we need to check for digit errors in the last couple of digits
+    // it's a whole number if all but the last one or two digits after the decimal place is 9 or 0 and the precision is >17 (arbitrary but enough)
+    if (precision > 17 && digits.length() > 3) {
+      int i = digits.length()-2;
+      char ch = digits.charAt(i); // second last character
+      if (ch == '9') {
+        while (i > 0 && digits.charAt(i-1) == '9') {
+          i--;
+        }      
+        if (i > 0 && i < digits.length() - 3) {
+          digits = digits.substring(0, i-1)+Character.toString((char) (digits.charAt(i-1) + 1));
+          precision = digits.length();
+        }
+      } else if (ch == '0') {
+        while (i > 0 && digits.charAt(i-1) == '0') {
+          i--;
+        }      
+        if (i > 0 && i < digits.length() - 3) {
+          digits = digits.substring(0, i);
+          precision = digits.length();
+        }
+      }
+    }
+  }
+  
 }

--- a/src/main/java/org/fhir/ucum/UcumEssenceService.java
+++ b/src/main/java/org/fhir/ucum/UcumEssenceService.java
@@ -297,6 +297,10 @@ public class UcumEssenceService implements UcumService {
 		if (!s.equals(d))
 			throw new UcumException("Unable to convert between units "+sourceUnit+" and "+destUnit+" as they do not have matching canonical forms ("+s+" and "+d+" respectively)");
 		Decimal canValue = value.multiply(src.getValue());
+		if (value.isWholeNumber()) {
+		  // whole numbers are tricky - they have implied infinite precision, but we need to check for digit errors in the last couple of digits
+		  canValue.checkForCouldBeWholeNumber();
+		}
 //		System.out.println(value.toPlainString()+sourceUnit+" =("+src.getValue().toPlainString()+")= "+
 //				canValue.toPlainString()+s+" =("+dst.getValue().toPlainString()+")= "+
 //				canValue.divide(dst.getValue())+destUnit);

--- a/src/test/java/org/fhir/ucum/UcumDecimalTester.java
+++ b/src/test/java/org/fhir/ucum/UcumDecimalTester.java
@@ -608,6 +608,39 @@ public class UcumDecimalTester {
       Assert.assertEquals(message, "6", res.asDecimal());
   }
 
+
+  @Test
+  public void testWholeNumberRounding() throws UcumException {
+    testRounding("1", "1");  
+    testRounding("0", "0");  
+    testRounding("9", "9");  
+    
+    testRounding("100", "100");  
+    testRounding("100.1", "100.1");  
+    testRounding("100.0000000000000000001", "100");  
+    testRounding("100.0000000000000000000", "100");  
+    testRounding("100.0000010000000000000", "100.000001");  
+    testRounding("100.0000000000000000010", "100.0000000000000000010");  
+    testRounding("100.0000010000000000100", "100.0000010000000000100");  
+    testRounding("100.0000010000000001000", "100.0000010000000001000");  
+    testRounding("100.0000010000000010000", "100.000001000000001");  
+    
+
+    testRounding("99", "99");  
+    testRounding("99.9", "99.9");  
+    testRounding("199.9999999999999999999", "200");  
+    testRounding("199.9999999999999999991", "200");  
+    testRounding("167.9999999999999999991", "168");  
+    testRounding("166.9999919999999999999", "166.999992");  
+
+  }
+  
+  private void testRounding(String value, String expected) throws UcumException {
+    Decimal dec = new Decimal(value);
+    dec.checkForCouldBeWholeNumber();
+    Assert.assertEquals(expected, dec.asDecimal());
+  }
+
   @Test
   public void testModulo() throws UcumException {
       Decimal res = new Decimal("10").modulo(new Decimal("1"));

--- a/src/test/java/org/fhir/ucum/UcumTester.java
+++ b/src/test/java/org/fhir/ucum/UcumTester.java
@@ -108,8 +108,10 @@ public class UcumTester {
         throw new UcumException("unknown element name "+focus.getNodeName());
       focus = XmlUtils.getNextSibling(focus);
     }
-    if (errCount > 0)
+    if (errCount > 0) {
       System.err.println(Integer.toString(errCount)+" errors");
+    }
+    Assert.assertEquals(0, errCount);
   }
 
   private void runMultiplication(Element x) throws IOException, UcumException  {

--- a/src/test/java/org/fhir/ucum/UcumTestsIsssue10.java
+++ b/src/test/java/org/fhir/ucum/UcumTestsIsssue10.java
@@ -11,20 +11,39 @@ public class UcumTestsIsssue10 {
 
   @Before
   public void setup() throws Exception {
-      ucumSvc = new UcumEssenceService("src/main/resources/ucum-essence.xml");
-      //ucumSvc = new UcumEssenceService(new FileInputStream("C:\\work\\org.hl7.fhir\\build\\tests\\ucum-essence.xml"));
+    ucumSvc = new UcumEssenceService("src/main/resources/ucum-essence.xml");
+    //ucumSvc = new UcumEssenceService(new FileInputStream("C:\\work\\org.hl7.fhir\\build\\tests\\ucum-essence.xml"));
   }
-  
+
   @Test
   public void KgToPoundTest() throws UcumException {
-      for (float i = 90.5f; i < 100f; i += 0.0001f) {
-//    float i = 90.7183f;
-          Decimal decimal = new Decimal(Float.toString(i));
-          float expectPound = i * 2.2046226218487758072297380134503f;
-          Decimal actual = ucumSvc.convert(decimal, "kg", "[lb_av]");
-          if (Math.abs(Float.parseFloat(actual.asDecimal()) - expectPound) > 0.001) {
-              System.out.println(i + " actual:" + actual + " expected:" + expectPound);
-          }
+    long start = System.currentTimeMillis();
+    for (float i = 90.5f; i < 100f; i += 0.0001f) {
+      //    float i = 90.7183f;
+      Decimal decimal = new Decimal(Float.toString(i));
+      float expectPound = i * 2.2046226218487758072297380134503f;
+      Decimal actual = ucumSvc.convert(decimal, "kg", "[lb_av]");
+      if (Math.abs(Float.parseFloat(actual.asDecimal()) - expectPound) > 0.001) {
+        System.out.println(i + " actual:" + actual + " expected:" + expectPound);
       }
+    }
+    System.out.println("elapsed = "+describeDuration(System.currentTimeMillis() - start));
   }
+  
+
+  public static String describeDuration(long ms) {
+    long days = ms / (1000 * 60 * 60 * 24);
+    long hours = ms / (1000 * 60 * 60) % 24;
+    long mins = ms / (1000 * 60) % 60;
+    long secs = ms / (1000) % 60;
+    ms = ms % 1000;
+    if (days > 0) {
+      return ""+days+"d "+hours+":"+mins+":"+secs+"."+ms;      
+    } else {
+      return ""+hours+":"+mins+":"+secs+"."+ms;
+    }
+    
+
+  }
+  
 }

--- a/src/test/java/org/fhir/ucum/UcumTestsIssue6_7.java
+++ b/src/test/java/org/fhir/ucum/UcumTestsIssue6_7.java
@@ -1,0 +1,45 @@
+package org.fhir.ucum;
+
+import java.io.IOException;
+import java.io.File;
+import java.io.InputStream;
+import java.io.FileInputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UcumTestsIssue6_7 {
+
+  @Test
+  public void testDecimalPrecision() throws IOException, UcumException {
+
+      String fileName = "ucum-essence.xml";
+      ClassLoader classLoader = getClass().getClassLoader();
+      File file = new File(classLoader.getResource(fileName).getFile());
+
+     InputStream inputStream = new FileInputStream(file);
+
+      UcumEssenceService ucumService = new UcumEssenceService(inputStream);
+      Decimal result = ucumService.convert(new Decimal("15"), "/min", "/h");
+      Assert.assertEquals("900", result.asDecimal());
+  }
+
+  @Test
+  public void testDecimalEquals() throws IOException, UcumException {
+
+      Decimal dec1 = new Decimal(42);
+      Decimal dec2 = new Decimal(42);
+      Assert.assertEquals(dec1, dec2);
+      
+
+      dec1 = new Decimal("42.00");
+      dec2 = new Decimal("42.00");
+      Assert.assertEquals(dec1, dec2);
+      
+      
+
+      dec1 = new Decimal("42.000");
+      dec2 = new Decimal("42.00");
+      Assert.assertNotEquals(dec1, dec2);
+  }
+}


### PR DESCRIPTION
Leaving the internals as string - makes a difference at the margins around precision. I know it's not the fastest, but accuracy is more important for this library